### PR TITLE
add netstandard2.0 and net461 support

### DIFF
--- a/Neleus.LambdaCompare.Tests/Neleus.LambdaCompare.Tests.csproj
+++ b/Neleus.LambdaCompare.Tests/Neleus.LambdaCompare.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.0</TargetFramework>    
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net461</TargetFrameworks>    
     <AssemblyName>Neleus.LambdaCompare.Tests</AssemblyName>    
     <RootNamespace>Neleus.LambdaCompare.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/Neleus.LambdaCompare/Neleus.LambdaCompare.csproj
+++ b/Neleus.LambdaCompare/Neleus.LambdaCompare.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>Neleus.LambdaCompare</AssemblyName>
     <RootNamespace>Neleus.LambdaCompare</RootNamespace>
     <Description>This project compares two lambda expressions recursively traversing their trees</Description>


### PR DESCRIPTION
Adding netstandard 2.0 removes the reference to NETStandard.Library. Adding net461 is suggested by Microsoft because of some compatipability problems.